### PR TITLE
[Feature] TwitterのOGPを表示できるようにする

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "preLaunchTask": "pnpm: build with source-maps",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["start"],
+      "envFile": "${workspaceFolder}/.env",
+      "killBehavior": "polite"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "dprint.dprint",
+  "editor.formatOnSave": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build:debug",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "pnpm: build with source-maps",
+      "detail": "swc --source-maps=true src --out-dir=dist"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fixup-twitter-link",
   "main": "dist/main.js",
+  "type": "module",
   "scripts": {
     "start": "node .",
     "dev": "node -r dotenv/config . dotenv_config_override=true",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly DISCORD_TOKEN: string | undefined;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,108 @@
-function main() {
-  console.log("Hello World");
-}
+import {
+  Client,
+  GatewayDispatchEvents,
+  GatewayIntentBits,
+  MessageFlags,
+  type APIEmbed,
+  type APIMessageReferenceSend,
+} from "@discordjs/core";
+import { REST } from "@discordjs/rest";
+import { WebSocketManager } from "@discordjs/ws";
 
-main()
+const token =
+  process.env.DISCORD_TOKEN ??
+  (() => {
+    throw new Error("DISCORD_TOKEN is not defined");
+  })();
+
+// Create REST and WebSocket managers directly
+const rest = new REST({ version: "10" }).setToken(token);
+
+const gateway = new WebSocketManager({
+  token: token,
+  intents: GatewayIntentBits.GuildMessages | GatewayIntentBits.MessageContent,
+  rest,
+});
+
+// Create a client to emit relevant events.
+const client = new Client({ rest, gateway });
+
+client.on(
+  GatewayDispatchEvents.MessageCreate,
+  async ({ data: message, api }) => {
+    if (!message.content || message.author.bot) {
+      return;
+    }
+
+    // Linkの取得
+    const TwitterOrXlinks = message.content.matchAll(
+      /https?:\/\/(?:www\.)?(?:x|twitter)\.com\/[^/]+\/status\/(?<id>\d+)/g
+    );
+
+    // match結果からidを取得
+    const ids = [...TwitterOrXlinks].map((match) => match.groups?.["id"]);
+    if (ids.length === 0) {
+      return;
+    }
+
+    // APIの呼び出し
+    const responses = await Promise.all(
+      ids.map((id) =>
+        fetch(`https://api.fxtwitter.com/status/${id}/`).then((res) =>
+          res.json()
+        )
+      )
+    );
+
+    // TwitterのOGPを削除する
+    await api.channels.editMessage(message.channel_id, message.id, {
+      flags: MessageFlags.SuppressEmbeds,
+    });
+
+    // Embedsの作成
+    let fixupxLinks: string[] = [];
+    const embeds = responses.flatMap((r) => {
+      const tweet = r.tweet;
+      if (tweet.poll || tweet.media?.videos || tweet.quote) {
+        fixupxLinks.push(`[_ ︎ _](https://fixupx.com/status/${tweet.id})`);
+        return []; // 動画や投票、引用のある場合はEmbedを作成しない
+      }
+
+      const embed: APIEmbed = {
+        description: tweet.text + `\n\n<t:${tweet.created_timestamp}:R>`,
+        color: 0x000,
+        footer: {
+          text: `𝕏 - 返信 ${tweet.replies} · リポスト ${tweet.retweets} · いいね ${tweet.likes}`,
+        },
+        image: {
+          url:
+            tweet.media?.mosaic?.formats?.webp ?? tweet.media?.photos?.[0]?.url,
+        },
+        author: {
+          name: tweet.author.name,
+          url: tweet.author.url,
+          icon_url: tweet.author.avatar_url,
+        },
+      };
+      return embed;
+    });
+
+    // 返信
+    const ref: APIMessageReferenceSend = {
+      channel_id: message.channel_id,
+      message_id: message.id,
+    };
+
+    await api.channels.createMessage(message.channel_id, {
+      embeds: embeds,
+      content: fixupxLinks.join("\n"),
+      message_reference: ref,
+    });
+  }
+);
+
+// Listen for the ready event
+client.once(GatewayDispatchEvents.Ready, () => console.log("Ready!"));
+
+// Start the WebSocket connection.
+gateway.connect();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,36 @@
 {
-  "extends": "@tsconfig/strictest",
+  "compileOnSave": true,
+  "include": ["src/**/*", "tests/**/*"],
   "compilerOptions": {
+    "strict": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+
+    "noUnusedParameters": false,
+
+    "module": "NodeNext",
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "removeComments": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "checkJs": true,
+    "verbatimModuleSyntax": true,
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "lib": ["ESNext"],
-    "types": ["node"],
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
+    "incremental": true,
+    "skipLibCheck": true,
+
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+
+    "noImplicitAny": false
+  }
 }


### PR DESCRIPTION
## 概要
- https://twitter.com/mogyuchi/status/1710024277783990335?s=61

Twitterのリンクが429で返されるのでfixupxを使って表示できるようにしていたが煩わしかったのでDiscordのbotで解決できるようにした。

## 実装内容
- 投稿からリンクを取得してfxtweetに渡して解析した結果をembedsに入れて再投稿させるようにした。
- 元の投稿のembedsは削除する
- 投票、引用、ビデオの投稿はハンドリングするの辛いのでfixupx.comのリンクを表示させそのOGPを表示するようにしている。