### PR TITLE
返信時に全てのメンションを無効化

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,12 @@ client.on(
       embeds: embeds,
       content: fixupxLinks.join("\n"),
       message_reference: ref,
+      allowed_mentions: {
+        parse: [],
+        roles: [],
+        users: [],
+        replied_user: false,
+      },
     });
   }
 );


### PR DESCRIPTION
返信時にメンションが有効な場合、このように受信ボックスなどにノイズが溜まるので無効化したほうがいいかなと思った。
<img width="485" alt="image" src="https://github.com/4m-mazi/fixup-twitter-link/assets/68449029/d97e9333-df72-45aa-8692-de3b629e6f21">
**全てのメンション**を無効化しているのはfxtwitterの気が狂った場合しか効果なさそうなのでまあ...
