### PR TITLE
APIで何も帰って来ない時のハンドリング追加

### DIFF
--- a/src/createEmbeds.ts
+++ b/src/createEmbeds.ts
@@ -21,18 +21,20 @@ export const createEmbeds = async (
       fetch(`https://api.fxtwitter.com/status/${id}/`)
         .then((res) => res.json())
         .then((data) => {
-          return (data as APITweetResponse).tweet;
+          return (data as APITweetResponse | undefined)?.tweet;
         })
     ),
   );
-  console.log(responses);
 
   // Embedsの作成
   const fixupxLinks: string[] = [];
   const embeds = responses
-    .filter((res) => res !== undefined) // たまに404が返ってくるので弾く
     .flatMap(
       (tweet) => {
+        if (!tweet) {
+          return [];
+        }
+
         if (tweet.poll ?? tweet.media?.videos ?? tweet.quote) {
           fixupxLinks.push(`[_ ︎ _](https://fixupx.com/status/${tweet.id})`);
           return []; // 動画や投票、引用のある場合はEmbedを作成しない

--- a/src/createEmbeds.ts
+++ b/src/createEmbeds.ts
@@ -25,33 +25,38 @@ export const createEmbeds = async (
         })
     ),
   );
+  console.log(responses);
 
   // Embedsの作成
   const fixupxLinks: string[] = [];
-  const embeds = responses.flatMap((tweet) => {
-    if (tweet.poll ?? tweet.media?.videos ?? tweet.quote) {
-      fixupxLinks.push(`[_ ︎ _](https://fixupx.com/status/${tweet.id})`);
-      return []; // 動画や投票、引用のある場合はEmbedを作成しない
-    }
+  const embeds = responses
+    .filter((res) => res !== undefined) // たまに404が返ってくるので弾く
+    .flatMap(
+      (tweet) => {
+        if (tweet.poll ?? tweet.media?.videos ?? tweet.quote) {
+          fixupxLinks.push(`[_ ︎ _](https://fixupx.com/status/${tweet.id})`);
+          return []; // 動画や投票、引用のある場合はEmbedを作成しない
+        }
 
-    const embed: APIEmbed = {
-      description: tweet.text + `\n\n<t:${tweet.created_timestamp}:R>`,
-      color: 0x000,
-      footer: {
-        text: `𝕏 - 返信 ${tweet.replies} · リポスト ${tweet.retweets} · いいね ${tweet.likes}`,
+        const embed: APIEmbed = {
+          description: tweet.text + `\n\n<t:${tweet.created_timestamp}:R>`,
+          color: 0x000,
+          footer: {
+            text: `𝕏 - 返信 ${tweet.replies} · リポスト ${tweet.retweets} · いいね ${tweet.likes}`,
+          },
+          image: {
+            url: tweet.media?.mosaic?.formats.webp
+              ?? tweet.media?.photos?.[0]?.url
+              ?? "",
+          },
+          author: {
+            name: tweet.author.name + `(@${tweet.author.screen_name})`,
+            url: tweet.author.avatar_url ?? "",
+            icon_url: tweet.author.avatar_url ?? "",
+          },
+        };
+        return embed;
       },
-      image: {
-        url: tweet.media?.mosaic?.formats.webp
-          ?? tweet.media?.photos?.[0]?.url
-          ?? "",
-      },
-      author: {
-        name: tweet.author.name + `(@${tweet.author.screen_name})`,
-        url: tweet.author.avatar_url ?? "",
-        icon_url: tweet.author.avatar_url ?? "",
-      },
-    };
-    return embed;
-  });
+    );
   return { embeds, fixupxLinks };
 };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -56,6 +56,21 @@ describe("fixup twitter link", () => {
     const result = await createEmbeds("テストな文字列");
     expect(result).toEqual(expected);
   });
+  it("APIが取得できない時は何も返さない", async () => {
+    mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            code: 404,
+            message: "Not Found",
+          }),
+      } as Response)
+    );
+    const expected = { embeds: [], fixupxLinks: [] };
+    const result = await createEmbeds("https://twitter.com/kcash510/status/1715221671974682986");
+    expect(result).toEqual(expected);
+  });
 
   it.todo("ツイートに動画がある投稿");
 });


### PR DESCRIPTION
たまにfxtwitterのAPIが404になるので、undefinedを弾くように変更
エラーで返したり、何回かリクエストしたりするのがいいんだろうけどめんどくさいので弾くだけ。

testのpromise rejectで返すべき？