### PR TITLE
fix: リンクを改行を入れずに羅列するように修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ client.on(
 
       await api.channels.createMessage(message.channel_id, {
         embeds: embeds,
-        content: fixupxLinks.join("\n"),
+        content: fixupxLinks.join(""),
         message_reference: ref,
         allowed_mentions: {
           parse: [],


### PR DESCRIPTION
fix #61 