### PR TITLE
chore: remove `container_name` specification

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,6 @@
 services:
   fixup-twitter-link-bot:
     image: fixup-twitter-link-bot
-    container_name: fixup-twitter-link-bot
     build: .
     pull_policy: build
     env_file: .env


### PR DESCRIPTION
Makes it possible to avoid container name conflicts.
