### PR TITLE
fix: separate fixupxLinks from embeds message creation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,17 +55,30 @@ client.on(
         message_id: message.id,
       } satisfies RESTAPIMessageReference;
 
-      await api.channels.createMessage(message.channel_id, {
-        embeds: embeds,
-        content: fixupxLinks.join(""),
-        message_reference: ref,
-        allowed_mentions: {
-          parse: [],
-          roles: [],
-          users: [],
-          replied_user: false,
-        },
-      });
+      if (fixupxLinks.length !== 0) {
+        await api.channels.createMessage(message.channel_id, {
+          content: fixupxLinks.join(""),
+          message_reference: ref,
+          allowed_mentions: {
+            parse: [],
+            roles: [],
+            users: [],
+            replied_user: false,
+          },
+        });
+      }
+      if (embeds.length !== 0) {
+        await api.channels.createMessage(message.channel_id, {
+          embeds: embeds,
+          message_reference: ref,
+          allowed_mentions: {
+            parse: [],
+            roles: [],
+            users: [],
+            replied_user: false,
+          },
+        });
+      }
     } catch (e) {
       Sentry.captureException(e);
     } finally {


### PR DESCRIPTION
embedが指定されたメッセージではリンクプレビューが行われないので、別々に送信する必要がある。