### PR TITLE
chore: update tsconfig to target Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@swc/core": "1.11.13",
     "@swc/helpers": "0.5.15",
     "@swc/jest": "0.2.37",
-    "@tsconfig/node20": "20.1.5",
+    "@tsconfig/node22": "22.0.1",
     "@tsconfig/strictest": "2.0.5",
     "@types/node": "22.13.14",
     "dotenv": "16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,9 @@ importers:
       '@swc/jest':
         specifier: 0.2.37
         version: 0.2.37(@swc/core@1.11.13(@swc/helpers@0.5.15))
-      '@tsconfig/node20':
-        specifier: 20.1.5
-        version: 20.1.5
+      '@tsconfig/node22':
+        specifier: 22.0.1
+        version: 22.0.1
       '@tsconfig/strictest':
         specifier: 2.0.5
         version: 2.0.5
@@ -1071,8 +1071,8 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tsconfig/node20@20.1.5':
-    resolution: {integrity: sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==}
+  '@tsconfig/node22@22.0.1':
+    resolution: {integrity: sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==}
 
   '@tsconfig/strictest@2.0.5':
     resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
@@ -3761,7 +3761,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tsconfig/node20@20.1.5': {}
+  '@tsconfig/node22@22.0.1': {}
 
   '@tsconfig/strictest@2.0.5': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node20/tsconfig"],
+  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node22/tsconfig"],
   "compilerOptions": {
     "noEmit": true,
     "composite": true,


### PR DESCRIPTION
Updates the TypeScript configuration and related dependencies to target Node.js version 22 instead of version 20.
